### PR TITLE
Replace full home access with access to XDG download directory

### DIFF
--- a/cn.feishu.Feishu.yaml
+++ b/cn.feishu.Feishu.yaml
@@ -16,7 +16,7 @@ finish-args:
   - --talk-name=org.gnome.keyring
   - --talk-name=org.gnome.ScreenSaver
   # Share files.
-  - --filesystem=home
+  - --filesystem=xdg-download
 separate-locales: false
 
 modules:


### PR DESCRIPTION
- According to [Flatpak documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access):
> Avoiding full home access and instead using XDG directories such as xdg-music or xdg-download etc.